### PR TITLE
feat: add match scheduling page with Google Calendar and chatbot

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import Calendar from './pages/Calendar';
 import Standings from './pages/Standings';
 import Admin from './pages/Admin';
 import Login from './pages/Login';
+import Schedule from './pages/Schedule';
 import ProtectedRoute from './components/ProtectedRoute';
 import './index.css';
 
@@ -22,8 +23,9 @@ function App() {
               <Route path="/calendario" element={<Calendar />} />
               <Route path="/clasificaciones" element={<Standings />} />
               <Route path="/login" element={<Login />} />
-              <Route 
-                path="/admin" 
+              <Route path="/programar" element={<Schedule />} />
+              <Route
+                path="/admin"
                 element={
                   <ProtectedRoute>
                     <Admin />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { Home, Calendar, Trophy, Settings, LogIn, LogOut, Menu, X } from 'lucide-react';
+import { Home, Calendar, Trophy, Settings, LogIn, LogOut, Menu, X, MessageCircle } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
 import { useTranslation } from 'react-i18next';
 
@@ -19,6 +19,7 @@ const Header: React.FC = () => {
     { name: t('header.nav.home'), path: '/', icon: Home },
     { name: t('header.nav.calendar'), path: '/calendario', icon: Calendar },
     { name: t('header.nav.standings'), path: '/clasificaciones', icon: Trophy },
+    { name: t('header.nav.schedule'), path: '/programar', icon: MessageCircle },
   ];
 
   const isActive = (path: string) => location.pathname === path;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -4,7 +4,8 @@
       "home": "Home",
       "calendar": "Calendar",
       "standings": "Standings",
-      "admin": "Admin"
+      "admin": "Admin",
+      "schedule": "Schedule Match"
     },
     "logout": "Logout",
     "login": "Login"

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -4,7 +4,8 @@
       "home": "Inicio",
       "calendar": "Calendario",
       "standings": "Clasificaciones",
-      "admin": "Admin"
+      "admin": "Admin",
+      "schedule": "Programar Partido"
     },
     "logout": "Salir",
     "login": "Entrar"

--- a/src/locales/la.json
+++ b/src/locales/la.json
@@ -4,7 +4,8 @@
       "home": "Domus",
       "calendar": "Calendarium",
       "standings": "Classificatio",
-      "admin": "Admin"
+      "admin": "Admin",
+      "schedule": "Certamen Disponere"
     },
     "logout": "Exire",
     "login": "Intrare"

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,10 +1,35 @@
 import React from 'react';
 import { motion } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+import { Calendar, Trophy, MessageCircle } from 'lucide-react';
 import LanguageSelector from '../components/LanguageSelector';
 
 const Home: React.FC = () => {
   const { t } = useTranslation();
+  const features = [
+    {
+      icon: Calendar,
+      title: 'Calendario',
+      description: 'Consulta la programación de partidos',
+      link: '/calendario',
+      color: 'text-blue-400',
+    },
+    {
+      icon: Trophy,
+      title: 'Clasificaciones',
+      description: 'Revisa las posiciones de la liga',
+      link: '/clasificaciones',
+      color: 'text-green-400',
+    },
+    {
+      icon: MessageCircle,
+      title: 'Programar Partido',
+      description: 'Usa el asistente para agendar tu partida',
+      link: '/programar',
+      color: 'text-red-400',
+    },
+  ];
   return (
     <div className="min-h-screen">
       <motion.section
@@ -30,6 +55,27 @@ const Home: React.FC = () => {
           <LanguageSelector />
         </div>
       </motion.section>
+
+      {/* Features Section */}
+      <section className="py-16">
+        <h2 className="text-4xl font-bold text-center mb-12">Explora la Liga</h2>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+          {features.map((feature) => {
+            const Icon = feature.icon;
+            return (
+              <Link
+                key={feature.link}
+                to={feature.link}
+                className="group block p-6 rounded-lg border border-gray-700 bg-black/40 hover:bg-black/60 transition"
+              >
+                <Icon className={`w-10 h-10 mb-4 ${feature.color}`} />
+                <h3 className="text-xl font-semibold mb-2">{feature.title}</h3>
+                <p className="text-gray-400">{feature.description}</p>
+              </Link>
+            );
+          })}
+        </div>
+      </section>
     </div>
   );
 };

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -1,0 +1,48 @@
+import React, { useEffect } from 'react';
+
+const Schedule: React.FC = () => {
+  useEffect(() => {
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'https://n8n.srv907628.hstgr.cloud/chat/widget.css';
+    document.head.appendChild(link);
+
+    const script = document.createElement('script');
+    script.src = 'https://n8n.srv907628.hstgr.cloud/chat/widget.js';
+    script.async = true;
+    script.onload = () => {
+      // @ts-ignore
+      if (window.n8nChat) {
+        // @ts-ignore
+        window.n8nChat.init('https://n8n.srv907628.hstgr.cloud/webhook/08edf318-16cd-4aa4-81a5-ea5e4013be78/chat');
+      }
+    };
+    document.body.appendChild(script);
+
+    return () => {
+      document.head.removeChild(link);
+      document.body.removeChild(script);
+    };
+  }, []);
+
+  return (
+    <div className="min-h-screen py-8">
+      <h1 className="text-4xl font-bold text-center mb-8">Programar un Partido</h1>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+        <div>
+          <iframe
+            src="https://calendar.google.com/calendar/embed?height=600&wkst=2&ctz=Europe%2FMadrid&showPrint=0&showTabs=0&showCalendars=0&mode=WEEK&title=La%20Catrina%20Pool%20League&src=MjZiMmIxNGVmZGI4OGMwZjM4MGNhYjkzZjU5YjM0NjczOTcwMWRlZWEyNmEwMWM3YmUwZmE2ZDE0YjIwYTQ5MUBncm91cC5jYWxlbmRhci5nb29nbGUuY29t&color=%237cb342"
+            style={{ border: 'solid 1px #777', width: '100%', height: '600px' }}
+            frameBorder="0"
+            scrolling="no"
+          ></iframe>
+        </div>
+        <div>
+          <div id="n8n-chat-widget" />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Schedule;


### PR DESCRIPTION
## Summary
- add Schedule page with embedded Google Calendar and n8n chatbot
- expose schedule page in router, navigation, translations and home features

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1c35ce350832998e5dbc96c4f1e42