### PR TITLE
Add calendar deletion and match result display

### DIFF
--- a/src/firebase/firestore.ts
+++ b/src/firebase/firestore.ts
@@ -160,5 +160,18 @@ export const matchesService = {
     });
 
     await batch.commit();
+  },
+
+  // Borrar todos los partidos del calendario
+  clearCalendar: async (): Promise<void> => {
+    const matchesRef = collection(db, 'matches');
+    const existing = await getDocs(matchesRef);
+    const batch = writeBatch(db);
+
+    existing.forEach((docSnap) => batch.delete(docSnap.ref));
+
+    await batch.commit();
   }
 };
+
+export { db, doc, writeBatch, Timestamp };

--- a/src/index.css
+++ b/src/index.css
@@ -1,10 +1,10 @@
+/* Importar fuentes de Google Fonts */
+@import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&family=Exo+2:wght@300;400;500;700&display=swap');
+
 /* Directivas de Tailwind CSS */
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-/* Importar fuentes de Google Fonts */
-@import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&family=Exo+2:wght@300;400;500;700&display=swap');
 
 :root {
   /* Colores principales */

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -233,7 +233,7 @@ const Admin: React.FC = () => {
       return;
     }
     try {
-      await matchesService.replaceCalendar([]);
+      await matchesService.clearCalendar();
       alert('El calendario ha sido borrado correctamente.');
     } catch (error) {
       console.error('Error borrando el calendario:', error);

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -185,14 +185,20 @@ const Calendar: React.FC = () => {
                       animate={{ opacity: 1, y: 0 }}
                       transition={{ duration: 0.4, delay: 0.05 * matchIndex }}
                     >
-                      {/* Jugadores */}
+                      {/* Jugadores y resultado */}
                       <div className="flex flex-col items-center justify-center space-y-2">
                         <span className="font-semibold text-lg text-blue-400 text-center">
                           {match.jugador1Nombre}
                         </span>
-                        <span className="text-center text-gray-500 font-bold text-sm">
-                          VS
-                        </span>
+                        {match.completado && match.resultado ? (
+                          <span className="text-center text-purple-400 font-bold text-sm">
+                            {match.resultado.setsJugador1} - {match.resultado.setsJugador2}
+                          </span>
+                        ) : (
+                          <span className="text-center text-gray-500 font-bold text-sm">
+                            VS
+                          </span>
+                        )}
                         <span className="font-semibold text-lg text-blue-400 text-center">
                           {match.jugador2Nombre}
                         </span>


### PR DESCRIPTION
## Summary
- add `clearCalendar` service to remove all scheduled matches
- allow admin panel to invoke calendar deletion
- show match results alongside players on calendar view

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6f3e974a08329b9e0d3f4868300bc